### PR TITLE
feat: add pi05 policy support

### DIFF
--- a/lerobot/src/lerobot/policies/__init__.py
+++ b/lerobot/src/lerobot/policies/__init__.py
@@ -15,6 +15,7 @@
 from .act.configuration_act import ACTConfig as ACTConfig
 from .diffusion.configuration_diffusion import DiffusionConfig as DiffusionConfig
 from .pi0.configuration_pi0 import PI0Config as PI0Config
+from .pi0.configuration_pi0 import PI05Config as PI05Config
 from .smolvla.configuration_smolvla import SmolVLAConfig as SmolVLAConfig
 from .tdmpc.configuration_tdmpc import TDMPCConfig as TDMPCConfig
 from .vqbet.configuration_vqbet import VQBeTConfig as VQBeTConfig

--- a/lerobot/src/lerobot/policies/factory.py
+++ b/lerobot/src/lerobot/policies/factory.py
@@ -26,7 +26,7 @@ from lerobot.envs.configs import EnvConfig
 from lerobot.envs.utils import env_to_policy_features
 from lerobot.policies.act.configuration_act import ACTConfig
 from lerobot.policies.diffusion.configuration_diffusion import DiffusionConfig
-from lerobot.policies.pi0.configuration_pi0 import PI0Config
+from lerobot.policies.pi0.configuration_pi0 import PI0Config, PI05Config
 from lerobot.policies.pi0fast.configuration_pi0fast import PI0FASTConfig
 from lerobot.policies.pretrained import PreTrainedPolicy
 from lerobot.policies.sac.configuration_sac import SACConfig
@@ -58,6 +58,10 @@ def get_policy_class(name: str) -> PreTrainedPolicy:
         from lerobot.policies.pi0.modeling_pi0 import PI0Policy
 
         return PI0Policy
+    elif name == "pi05":
+        from lerobot.policies.pi0.modeling_pi0 import PI05Policy
+
+        return PI05Policy
     elif name == "pi0fast":
         from lerobot.policies.pi0fast.modeling_pi0fast import PI0FASTPolicy
 
@@ -89,6 +93,8 @@ def make_policy_config(policy_type: str, **kwargs) -> PreTrainedConfig:
         return VQBeTConfig(**kwargs)
     elif policy_type == "pi0":
         return PI0Config(**kwargs)
+    elif policy_type == "pi05":
+        return PI05Config(**kwargs)
     elif policy_type == "pi0fast":
         return PI0FASTConfig(**kwargs)
     elif policy_type == "sac":

--- a/lerobot/src/lerobot/policies/pi0/configuration_pi0.py
+++ b/lerobot/src/lerobot/policies/pi0/configuration_pi0.py
@@ -60,6 +60,9 @@ class PI0Config(PreTrainedConfig):
     # Tokenizer
     tokenizer_max_length: int = 48
 
+    # Model variants
+    pi05: bool = False
+
     # Projector
     proj_width: int = 1024
 
@@ -92,6 +95,8 @@ class PI0Config(PreTrainedConfig):
 
         # TODO(Steven): Validate device and amp? in all policy configs?
         """Input validation (not exhaustive)."""
+        if self.pi05 and self.tokenizer_max_length < 200:
+            self.tokenizer_max_length = 200
         if self.n_action_steps > self.chunk_size:
             raise ValueError(
                 f"The chunk size is the upper bound for the number of action steps per model invocation. Got "
@@ -139,6 +144,17 @@ class PI0Config(PreTrainedConfig):
     @property
     def observation_delta_indices(self) -> None:
         return None
+
+
+@PreTrainedConfig.register_subclass("pi05")
+@dataclass
+class PI05Config(PI0Config):
+    pi05: bool = True
+    tokenizer_max_length: int = 200
+
+    def __post_init__(self):
+        self.pi05 = True
+        super().__post_init__()
 
     @property
     def action_delta_indices(self) -> list:

--- a/lerobot/src/lerobot/policies/pi0/modeling_pi0.py
+++ b/lerobot/src/lerobot/policies/pi0/modeling_pi0.py
@@ -60,7 +60,7 @@ from transformers import AutoTokenizer
 
 from lerobot.constants import ACTION, OBS_STATE
 from lerobot.policies.normalize import Normalize, Unnormalize
-from lerobot.policies.pi0.configuration_pi0 import PI0Config
+from lerobot.policies.pi0.configuration_pi0 import PI0Config, PI05Config
 from lerobot.policies.pi0.paligemma_with_expert import (
     PaliGemmaWithExpertConfig,
     PaliGemmaWithExpertModel,
@@ -487,11 +487,24 @@ class PI0Policy(PreTrainedPolicy):
         device = batch[OBS_STATE].device
         tasks = batch["task"]
 
-        # PaliGemma prompt has to end with a new line
-        tasks = [task if task.endswith("\n") else f"{task}\n" for task in tasks]
+        if self.config.pi05:
+            states = batch[OBS_STATE]
+            if self.config.robot_state_feature is not None:
+                original_state_dim = self.config.robot_state_feature.shape[0]
+                states = states[:, :original_state_dim]
+            discretized_states = self._discretize_state(states)
+
+            prompts = []
+            for task, state_tokens in zip(tasks, discretized_states.tolist(), strict=False):
+                cleaned_text = task.strip().replace("_", " ").replace("\n", " ")
+                state_str = " ".join(map(str, state_tokens))
+                prompts.append(f"Task: {cleaned_text}, State: {state_str};\nAction: ")
+        else:
+            # PaliGemma prompt has to end with a new line
+            prompts = [task if task.endswith("\n") else f"{task}\n" for task in tasks]
 
         tokenized_prompt = self.language_tokenizer.__call__(
-            tasks,
+            prompts,
             padding="max_length",
             padding_side="right",
             max_length=self.config.tokenizer_max_length,
@@ -501,6 +514,27 @@ class PI0Policy(PreTrainedPolicy):
         lang_masks = tokenized_prompt["attention_mask"].to(device=device, dtype=torch.bool)
 
         return lang_tokens, lang_masks
+
+    def _discretize_state(self, state: Tensor) -> Tensor:
+        bins = torch.linspace(-1, 1, steps=256 + 1, device=state.device, dtype=state.dtype)[:-1]
+        indices = torch.bucketize(state, bins)
+        indices = torch.clamp(indices - 1, min=0, max=255)
+        return indices.to(torch.int64)
+
+
+class PI05Policy(PI0Policy):
+    """Policy wrapper for pi0.5 checkpoints."""
+
+    config_class = PI05Config
+    name = "pi05"
+
+    def __init__(
+        self,
+        config: PI05Config,
+        dataset_stats: dict[str, dict[str, Tensor]] | None = None,
+    ):
+        config.pi05 = True
+        super().__init__(config, dataset_stats)
 
     def _pi_aloha_decode_state(self, state):
         # Flip the joints.
@@ -570,27 +604,33 @@ class PI0FlowMatching(nn.Module):
     def __init__(self, config):
         super().__init__()
         self.config = config
+        self.pi05 = config.pi05
 
         paligemma_with_export_config = PaliGemmaWithExpertConfig(
             freeze_vision_encoder=self.config.freeze_vision_encoder,
             train_expert_only=self.config.train_expert_only,
             attention_implementation=self.config.attention_implementation,
+            use_adaptive_norm=self.pi05,
         )
         self.paligemma_with_expert = PaliGemmaWithExpertModel(paligemma_with_export_config)
 
         # Projections are float32
-        self.state_proj = nn.Linear(self.config.max_state_dim, self.config.proj_width)
         self.action_in_proj = nn.Linear(self.config.max_action_dim, self.config.proj_width)
         self.action_out_proj = nn.Linear(self.config.proj_width, self.config.max_action_dim)
-
-        self.action_time_mlp_in = nn.Linear(self.config.proj_width * 2, self.config.proj_width)
-        self.action_time_mlp_out = nn.Linear(self.config.proj_width, self.config.proj_width)
+        if self.pi05:
+            self.time_mlp_in = nn.Linear(self.config.proj_width, self.config.proj_width)
+            self.time_mlp_out = nn.Linear(self.config.proj_width, self.config.proj_width)
+        else:
+            self.state_proj = nn.Linear(self.config.max_state_dim, self.config.proj_width)
+            self.action_time_mlp_in = nn.Linear(self.config.proj_width * 2, self.config.proj_width)
+            self.action_time_mlp_out = nn.Linear(self.config.proj_width, self.config.proj_width)
 
         self.set_requires_grad()
 
     def set_requires_grad(self):
-        for params in self.state_proj.parameters():
-            params.requires_grad = self.config.train_state_proj
+        if hasattr(self, "state_proj"):
+            for params in self.state_proj.parameters():
+                params.requires_grad = self.config.train_state_proj
 
     def sample_noise(self, shape, device):
         noise = torch.normal(
@@ -665,20 +705,26 @@ class PI0FlowMatching(nn.Module):
         embs = []
         pad_masks = []
         att_masks = []
+        adarms_cond = None
 
-        # Embed state
-        state_emb = self.state_proj(state)
-        state_emb = state_emb.to(dtype=torch.bfloat16)
-        embs.append(state_emb[:, None, :])
-        bsize = state_emb.shape[0]
-        dtype = state_emb.dtype
-        device = state_emb.device
+        if not self.pi05:
+            # Embed state
+            state_emb = self.state_proj(state)
+            state_emb = state_emb.to(dtype=torch.bfloat16)
+            embs.append(state_emb[:, None, :])
+            bsize = state_emb.shape[0]
+            dtype = state_emb.dtype
+            device = state_emb.device
 
-        state_mask = torch.ones(bsize, 1, dtype=torch.bool, device=device)
-        pad_masks.append(state_mask)
+            state_mask = torch.ones(bsize, 1, dtype=torch.bool, device=device)
+            pad_masks.append(state_mask)
 
-        # Set attention masks so that image and language inputs do not attend to state or actions
-        att_masks += [1]
+            # Set attention masks so that image and language inputs do not attend to state or actions
+            att_masks += [1]
+        else:
+            bsize = noisy_actions.shape[0]
+            dtype = noisy_actions.dtype
+            device = noisy_actions.device
 
         # Embed timestep using sine-cosine positional encoding with sensitivity in the range [0, 1]
         time_emb = create_sinusoidal_pos_embedding(
@@ -689,12 +735,21 @@ class PI0FlowMatching(nn.Module):
         # Fuse timestep + action information using an MLP
         action_emb = self.action_in_proj(noisy_actions)
 
-        time_emb = time_emb[:, None, :].expand_as(action_emb)
-        action_time_emb = torch.cat([action_emb, time_emb], dim=2)
+        if self.pi05:
+            action_emb = action_emb.to(dtype=torch.bfloat16)
+            time_emb = self.time_mlp_in(time_emb)
+            time_emb = F.silu(time_emb)
+            time_emb = self.time_mlp_out(time_emb)
+            time_emb = F.silu(time_emb)
+            action_time_emb = action_emb
+            adarms_cond = time_emb.to(dtype=action_time_emb.dtype)
+        else:
+            time_emb = time_emb[:, None, :].expand_as(action_emb)
+            action_time_emb = torch.cat([action_emb, time_emb], dim=2)
 
-        action_time_emb = self.action_time_mlp_in(action_time_emb)
-        action_time_emb = F.silu(action_time_emb)  # swish == silu
-        action_time_emb = self.action_time_mlp_out(action_time_emb)
+            action_time_emb = self.action_time_mlp_in(action_time_emb)
+            action_time_emb = F.silu(action_time_emb)  # swish == silu
+            action_time_emb = self.action_time_mlp_out(action_time_emb)
 
         # Add to input tokens
         embs.append(action_time_emb)
@@ -711,7 +766,7 @@ class PI0FlowMatching(nn.Module):
         att_masks = torch.tensor(att_masks, dtype=embs.dtype, device=embs.device)
         att_masks = att_masks[None, :].expand(bsize, len(att_masks))
 
-        return embs, pad_masks, att_masks
+        return embs, pad_masks, att_masks, adarms_cond
 
     def forward(
         self, images, img_masks, lang_tokens, lang_masks, state, actions, noise=None, time=None
@@ -730,13 +785,15 @@ class PI0FlowMatching(nn.Module):
         prefix_embs, prefix_pad_masks, prefix_att_masks = self.embed_prefix(
             images, img_masks, lang_tokens, lang_masks
         )
-        suffix_embs, suffix_pad_masks, suffix_att_masks = self.embed_suffix(state, x_t, time)
+        suffix_embs, suffix_pad_masks, suffix_att_masks, adarms_cond = self.embed_suffix(state, x_t, time)
 
         pad_masks = torch.cat([prefix_pad_masks, suffix_pad_masks], dim=1)
         att_masks = torch.cat([prefix_att_masks, suffix_att_masks], dim=1)
 
         att_2d_masks = make_att_2d_masks(pad_masks, att_masks)
         position_ids = torch.cumsum(pad_masks, dim=1) - 1
+
+        adarms_inputs = [None, adarms_cond] if adarms_cond is not None else [None, None]
 
         (_, suffix_out), _ = self.paligemma_with_expert.forward(
             attention_mask=att_2d_masks,
@@ -745,6 +802,7 @@ class PI0FlowMatching(nn.Module):
             inputs_embeds=[prefix_embs, suffix_embs],
             use_cache=False,
             fill_kv_cache=False,
+            adarms_cond=adarms_inputs,
         )
         suffix_out = suffix_out[:, -self.config.n_action_steps :]
         # Original openpi code, upcast attention output
@@ -808,7 +866,7 @@ class PI0FlowMatching(nn.Module):
         timestep,
     ):
         """Apply one denoising step of the noise `x_t` at a given timestep."""
-        suffix_embs, suffix_pad_masks, suffix_att_masks = self.embed_suffix(state, x_t, timestep)
+        suffix_embs, suffix_pad_masks, suffix_att_masks, adarms_cond = self.embed_suffix(state, x_t, timestep)
 
         suffix_len = suffix_pad_masks.shape[1]
         batch_size = prefix_pad_masks.shape[0]
@@ -822,6 +880,8 @@ class PI0FlowMatching(nn.Module):
         prefix_offsets = torch.sum(prefix_pad_masks, dim=-1)[:, None]
         position_ids = prefix_offsets + torch.cumsum(suffix_pad_masks, dim=1) - 1
 
+        adarms_inputs = [None, adarms_cond] if adarms_cond is not None else [None, None]
+
         outputs_embeds, _ = self.paligemma_with_expert.forward(
             attention_mask=full_att_2d_masks,
             position_ids=position_ids,
@@ -829,6 +889,7 @@ class PI0FlowMatching(nn.Module):
             inputs_embeds=[None, suffix_embs],
             use_cache=self.config.use_cache,
             fill_kv_cache=False,
+            adarms_cond=adarms_inputs,
         )
         suffix_out = outputs_embeds[1]
         suffix_out = suffix_out[:, -self.config.n_action_steps :]

--- a/lerobot/src/lerobot/policies/pi0/paligemma_with_expert.py
+++ b/lerobot/src/lerobot/policies/pi0/paligemma_with_expert.py
@@ -17,6 +17,7 @@ import torch
 import torch.version
 from pytest import Cache
 from torch import nn
+from typing import Optional
 from transformers import (
     AutoConfig,
     GemmaForCausalLM,
@@ -55,6 +56,78 @@ def apply_rope(x, positions, max_wavelength=10_000):
     return res.to(dtype)
 
 
+def _gated_residual(residual: torch.Tensor, hidden_states: torch.Tensor, gate: Optional[torch.Tensor]) -> torch.Tensor:
+    if gate is None:
+        return residual + hidden_states
+    gate = torch.sigmoid(gate)
+    # Broadcast gate if necessary
+    while gate.ndim < hidden_states.ndim:
+        gate = gate.unsqueeze(1)
+    return residual + gate * hidden_states
+
+
+class AdaptiveRMSNorm(nn.Module):
+    def __init__(self, dim: int, eps: float = 1e-6, cond_dim: Optional[int] = None):
+        super().__init__()
+        self.eps = eps
+        self.dim = dim
+        self.cond_dim = cond_dim
+
+        if cond_dim is None:
+            self.weight = nn.Parameter(torch.zeros(dim, dtype=torch.bfloat16))
+            nn.init.zeros_(self.weight)
+            self.dense: nn.Linear | None = None
+        else:
+            self.weight = None
+            self.dense = nn.Linear(cond_dim, dim * 3, bias=True)
+            nn.init.zeros_(self.dense.weight)
+            nn.init.zeros_(self.dense.bias)
+
+    def _norm(self, x: torch.Tensor) -> torch.Tensor:
+        var = torch.mean(torch.square(x.float()), dim=-1, keepdim=True)
+        normed = x * torch.rsqrt(var + self.eps)
+        return normed
+
+    def forward(self, x: torch.Tensor, cond: Optional[torch.Tensor] = None) -> tuple[torch.Tensor, Optional[torch.Tensor]]:
+        dtype = x.dtype
+        normed = self._norm(x).to(dtype)
+
+        if self.dense is None or cond is None:
+            if self.weight is None:
+                return normed, None
+            weight = (1.0 + self.weight.float()).to(dtype)
+            return normed * weight, None
+
+        if cond.shape[-1] != self.cond_dim:
+            raise ValueError(f"Expected cond dim {self.cond_dim}, got {cond.shape[-1]}")
+
+        modulation = self.dense(cond)
+        if modulation.ndim == 2:
+            modulation = modulation.unsqueeze(1)
+        scale, shift, gate = modulation.chunk(3, dim=-1)
+        normed = normed * (1 + scale.float()) + shift.float()
+        return normed.to(dtype), gate.to(dtype)
+
+    @classmethod
+    def from_rms_norm(
+        cls,
+        module: nn.Module,
+        *,
+        cond_dim: Optional[int] = None,
+    ) -> "AdaptiveRMSNorm":
+        eps = getattr(module, "variance_epsilon", getattr(module, "eps", 1e-6))
+        if not hasattr(module, "weight") or module.weight is None:
+            raise ValueError("Cannot convert module without `weight` parameter to AdaptiveRMSNorm")
+        dim = module.weight.shape[0]
+        dtype = module.weight.dtype
+        device = module.weight.device
+
+        adaptive = cls(dim, eps=eps, cond_dim=cond_dim)
+        adaptive = adaptive.to(device=device)
+        if cond_dim is None and hasattr(module, "weight") and module.weight is not None:
+            adaptive.weight.data.copy_(module.weight.data.to(adaptive.weight.dtype))
+        return adaptive.to(dtype=dtype)
+
 class PaliGemmaWithExpertConfig(PretrainedConfig):
     model_type = "PaliGemmaWithExpertModel"
     sub_configs = {"paligemma_config": AutoConfig, "gemma_expert_config": AutoConfig}
@@ -66,11 +139,13 @@ class PaliGemmaWithExpertConfig(PretrainedConfig):
         freeze_vision_encoder: bool = True,
         train_expert_only: bool = True,
         attention_implementation: str = "eager",
+        use_adaptive_norm: bool = False,
         **kwargs,
     ):
         self.freeze_vision_encoder = freeze_vision_encoder
         self.train_expert_only = train_expert_only
         self.attention_implementation = attention_implementation
+        self.use_adaptive_norm = use_adaptive_norm
 
         if paligemma_config is None:
             # Default config from Pi0
@@ -178,6 +253,9 @@ class PaliGemmaWithExpertModel(PreTrainedModel):
         # Remove unused embed_tokens
         self.gemma_expert.model.embed_tokens = None
 
+        if self.config.use_adaptive_norm:
+            self._inject_adaptive_norm()
+
         self.to_bfloat16_like_physical_intelligence()
         self.set_requires_grad()
 
@@ -191,6 +269,19 @@ class PaliGemmaWithExpertModel(PreTrainedModel):
             self.paligemma.eval()
             for params in self.paligemma.parameters():
                 params.requires_grad = False
+
+    def _inject_adaptive_norm(self) -> None:
+        cond_dim = self.gemma_expert.config.hidden_size
+        for layer in self.gemma_expert.model.layers:
+            layer.input_layernorm = AdaptiveRMSNorm.from_rms_norm(
+                layer.input_layernorm, cond_dim=cond_dim
+            )
+            layer.post_attention_layernorm = AdaptiveRMSNorm.from_rms_norm(
+                layer.post_attention_layernorm, cond_dim=cond_dim
+            )
+        self.gemma_expert.model.norm = AdaptiveRMSNorm.from_rms_norm(
+            self.gemma_expert.model.norm, cond_dim=cond_dim
+        )
 
     def train(self, mode: bool = True):
         super().train(mode)
@@ -233,8 +324,28 @@ class PaliGemmaWithExpertModel(PreTrainedModel):
         inputs_embeds: list[torch.FloatTensor] = None,
         use_cache: bool | None = None,
         fill_kv_cache: bool | None = None,
+        adarms_cond: list[torch.Tensor | None] | None = None,
     ):
         models = [self.paligemma.language_model, self.gemma_expert.model]
+
+        if adarms_cond is None:
+            adarms_cond = [None, None]
+        else:
+            adarms_cond = list(adarms_cond)
+        if len(adarms_cond) < len(inputs_embeds):
+            adarms_cond += [None] * (len(inputs_embeds) - len(adarms_cond))
+
+        def apply_norm(module, tensor, cond):
+            if cond is not None:
+                try:
+                    result = module(tensor, cond=cond)
+                except TypeError:
+                    result = module(tensor)
+            else:
+                result = module(tensor)
+            if isinstance(result, tuple):
+                return result
+            return result, None
 
         for hidden_states in inputs_embeds:
             # TODO this is very inefficient
@@ -251,13 +362,14 @@ class PaliGemmaWithExpertModel(PreTrainedModel):
             query_states = []
             key_states = []
             value_states = []
+            residuals = [None] * len(inputs_embeds)
+            input_gates: list[torch.Tensor | None] = [None] * len(inputs_embeds)
             for i, hidden_states in enumerate(inputs_embeds):
                 if hidden_states is None:
                     continue
                 layer = models[i].layers[layer_idx]
-                # normalizer = torch.tensor(models[i].config.hidden_size**0.5, dtype=hidden_states.dtype)
-                # hidden_states = hidden_states * normalizer
-                hidden_states = layer.input_layernorm(hidden_states)
+                residuals[i] = hidden_states
+                hidden_states, gate = apply_norm(layer.input_layernorm, hidden_states, adarms_cond[i])
 
                 input_shape = hidden_states.shape[:-1]
                 hidden_shape = (*input_shape, -1, layer.self_attn.head_dim)
@@ -267,6 +379,7 @@ class PaliGemmaWithExpertModel(PreTrainedModel):
                 key_state = layer.self_attn.k_proj(hidden_states).view(hidden_shape)
                 value_state = layer.self_attn.v_proj(hidden_states).view(hidden_shape)
 
+                input_gates[i] = gate
                 query_states.append(query_state)
                 key_states.append(key_state)
                 value_states.append(value_state)
@@ -314,23 +427,18 @@ class PaliGemmaWithExpertModel(PreTrainedModel):
                 if hidden_states is not None:
                     end = start + hidden_states.shape[1]
 
-                    if att_output.dtype != layer.self_attn.o_proj.weight.dtype:
-                        att_output = att_output.to(layer.self_attn.o_proj.weight.dtype)
+                    target_dtype = layer.self_attn.o_proj.weight.dtype
+                    if att_output.dtype != target_dtype:
+                        att_output = att_output.to(target_dtype)
                     out_emb = layer.self_attn.o_proj(att_output[:, start:end])
 
-                    # TODO: first dropout (by default 0.0)
-
-                    # first residual
-                    out_emb += hidden_states
+                    out_emb = _gated_residual(residuals[i], out_emb, input_gates[i])
                     after_first_residual = out_emb.clone()
 
-                    out_emb = layer.post_attention_layernorm(out_emb)
+                    out_emb, post_gate = apply_norm(layer.post_attention_layernorm, out_emb, adarms_cond[i])
                     out_emb = layer.mlp(out_emb)
 
-                    # TODO: second dropout (by default 0.0)
-
-                    # second residual
-                    out_emb += after_first_residual
+                    out_emb = _gated_residual(after_first_residual, out_emb, post_gate)
 
                     outputs_embeds.append(out_emb)
 
@@ -344,7 +452,7 @@ class PaliGemmaWithExpertModel(PreTrainedModel):
         outputs_embeds = []
         for i, hidden_states in enumerate(inputs_embeds):
             if hidden_states is not None:
-                out_emb = models[i].norm(hidden_states)
+                out_emb, _ = apply_norm(models[i].norm, hidden_states, adarms_cond[i])
                 outputs_embeds.append(out_emb)
             else:
                 outputs_embeds.append(None)

--- a/lerobot/src/lerobot/scripts/server/constants.py
+++ b/lerobot/src/lerobot/scripts/server/constants.py
@@ -23,7 +23,7 @@ DEFAULT_INFERENCE_LATENCY = 1 / DEFAULT_FPS
 DEFAULT_OBS_QUEUE_TIMEOUT = 2
 
 # All action chunking policies
-SUPPORTED_POLICIES = ["act", "smolvla", "diffusion", "pi0", "tdmpc", "vqbet"]
+SUPPORTED_POLICIES = ["act", "smolvla", "diffusion", "pi0", "pi05", "tdmpc", "vqbet"]
 
 # TODO: Add all other robots
 SUPPORTED_ROBOTS = ["so100_follower", "so101_follower"]

--- a/lerobot/src/lerobot/templates/lerobot_modelcard_template.md
+++ b/lerobot/src/lerobot/templates/lerobot_modelcard_template.md
@@ -21,6 +21,8 @@
 [VQ-BET](https://huggingface.co/papers/2403.03181) combines vector-quantised action tokens with Behaviour Transformers to discretise control and achieve data-efficient imitation across diverse skills.
 {% elif model_name == "pi0" %}
 [Pi0](https://huggingface.co/papers/2410.24164) is a generalist vision-language-action transformer that converts multimodal observations and text instructions into robot actions for zero-shot task transfer.
+{% elif model_name == "pi05" %}
+[Pi0.5](https://www.physicalintelligence.company/blog/pi05) extends Pi0 with discrete state tokenisation and adaptive normalization in the action head, improving open-world generalization for robotic manipulation tasks.
 {% elif model_name == "pi0fast" %}
 [Pi0-Fast](https://huggingface.co/papers/2501.09747) is a variant of Pi0 that uses a new tokenization method called FAST, which enables training of an autoregressive vision-language-action policy for high-frequency robotic tasks with improved performance and reduced training time.
 {% elif model_name == "sac" %}


### PR DESCRIPTION
## Summary
- introduce PI05Config/Policy and extend pi0 configuration to enable discrete state prompts
- add adaptive RMSNorm handling in the pi0 PaliGemma expert to support pi0.5 time conditioning
- register the new policy type across the factory, server constants, and model card metadata

## Testing
- python -m compileall lerobot/src/lerobot/policies/pi0
- PYTHONPATH=lerobot/src pytest lerobot/tests/policies/test_policies.py

------
https://chatgpt.com/codex/tasks/task_e_68c8fc86a3ac832eb5bbb29ba46b0341